### PR TITLE
Support key share selection

### DIFF
--- a/components/ChooseKeyShare.tsx
+++ b/components/ChooseKeyShare.tsx
@@ -1,0 +1,74 @@
+import React, {useState} from "react";
+import type { KeyringAccount } from "@metamask/keyring-api";
+
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
+import Icons from "@/components/Icons";
+
+function AlertContent({shares, onChange}: { shares: string[], onChange: (shareId: string) => void }) {
+  return (
+    <AlertDialogHeader>
+      <AlertDialogTitle>Choose Key Share</AlertDialogTitle>
+      <AlertDialogDescription>
+        Choose the key share to use to sign this transaction. If you are signing with multiple key shares you <strong>must use a unique key share</strong>.
+      </AlertDialogDescription>
+      <RadioGroup
+        className="pt-4"
+        defaultValue={shares[0]}
+        onValueChange={onChange}>
+        {shares.map((shareId: string, index: number) => {
+          return <div key={index} className="flex items-center space-x-2">
+            <RadioGroupItem value={shareId} id={shareId} />
+            <Label htmlFor={shareId}>Share {shareId}</Label>
+          </div>;
+        })}
+      </RadioGroup>
+    </AlertDialogHeader>
+  );
+}
+
+export default function ChooseKeyShare({
+  account,
+  button,
+  shares,
+  onConfirm,
+}: {
+  account: KeyringAccount;
+  button: React.ReactNode;
+  shares: string[];
+  onConfirm: (shareId: string) => void;
+}) {
+  const [shareId, setShareId] = useState(shares[0]);
+  const chooseKeyShare = async () => {
+    onConfirm(shareId);
+  };
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        {button}
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertContent shares={shares} onChange={(shareId) => setShareId(shareId)} />
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={chooseKeyShare}>
+            OK
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/MeetingPoint.tsx
+++ b/components/MeetingPoint.tsx
@@ -13,6 +13,7 @@ import {
   KeyShareAudience,
   MeetingInfo,
   SessionState,
+  SessionType,
   OwnerType,
   JoinMeeting,
 } from "@/app/model";
@@ -29,11 +30,13 @@ import {
 } from "@/lib/utils";
 
 function Invitations({
+  session,
   meetingInfo,
   audience,
   inviteParams,
   linkPrefix,
 }: {
+  session: SessionState;
   meetingInfo: MeetingInfo;
   audience: KeyShareAudience;
   inviteParams?: Dictionary<string>;
@@ -44,7 +47,10 @@ function Invitations({
     await copyWithToast(value, toast);
   };
 
-  const participants = meetingInfo.identifiers.slice(1);
+  const participants = session.sessionType === SessionType.keygen
+    ? meetingInfo.identifiers.slice(1)
+    : meetingInfo.identifiers.slice(1);
+    //: meetingInfo.identifiers.slice(1, session.threshold + 1);
   return (
     <div className="rounded-md border">
       {participants.map((userId, index) => {
@@ -177,6 +183,7 @@ export default function MeetingPoint({
       <div className="flex flex-col space-y-6">
         <Loader text="Waiting for everybody to join..." />
         <Invitations
+          session={session}
           linkPrefix={linkPrefix}
           meetingInfo={meetingInfo}
           inviteParams={{

--- a/components/MeetingPoint.tsx
+++ b/components/MeetingPoint.tsx
@@ -49,8 +49,7 @@ function Invitations({
 
   const participants = session.sessionType === SessionType.keygen
     ? meetingInfo.identifiers.slice(1)
-    : meetingInfo.identifiers.slice(1);
-    //: meetingInfo.identifiers.slice(1, session.threshold + 1);
+    : meetingInfo.identifiers.slice(1, session.threshold + 1);
   return (
     <div className="rounded-md border">
       {participants.map((userId, index) => {

--- a/components/MeetingPoint.tsx
+++ b/components/MeetingPoint.tsx
@@ -122,11 +122,16 @@ export default function MeetingPoint({
     };
 
     const createMeetingPoint = async () => {
-      const { parties } = session as CreateKeyState;
+      const { sessionType, parties, threshold } = session as CreateKeyState;
       const identifiers: string[] = [];
 
+      // Number of identifiers which are the slots for a meeting point
+      const numIdentifiers = sessionType === SessionType.keygen
+        ? parties
+        : threshold + 1;
+
       /* eslint-disable @typescript-eslint/no-unused-vars */
-      for (let i = 0; i < parties; i++) {
+      for (let i = 0; i < numIdentifiers; i++) {
         const value = uuidv4();
         const hash = await digest(value);
         identifiers.push(hash);

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -19,7 +19,10 @@
   },
   "initialPermissions": {
     "endowment:keyring": {
-      "allowedOrigins": ["https://tss.ac", "http://localhost:7070"]
+      "allowedOrigins": [
+        "https://tss.ac",
+        "http://localhost:7070"
+      ]
     },
     "endowment:rpc": {
       "dapps": true,


### PR DESCRIPTION
For the case when there is more than one remaining shares when joining a transaction.

Includes an important fix for the number of slots in a meeting point.

Closes #25