### PR TITLE
Use absolute server path for index.js.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,16 @@
+# Release
+
+First tag a version and push it:
+
+```
+git tag v0.1.2
+git push origin v0.1.2
+```
+
+Once the github action has created the release artifacts then publish the snap:
+
+```
+yarn run publish
+```
+
+Even if the snap code has not changed publish so that the version in the npm registry is in sync with the downloads available on github releases.

--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link href="favicon.png" rel="shortcut icon" type="image/x-icon">
+    <link href="/favicon.png" rel="shortcut icon" type="image/x-icon">
     <link href="/styles.css" rel="stylesheet">
     <title>Multi-Factor Accounts</title>
   </head>
   <body>
     <main></main>
     <noscript>This page contains webassembly and javascript content, please enable javascript in your browser.</noscript>
-    <script src="./index.js"></script>
+    <script src="/index.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mpc-sdk/multi-factor-accounts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Adds multi-factor accounts to MetaMask by sharding keys using threshold signatures",
   "repository": {
     "type": "git",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Adds multi-factor accounts to MetaMask by sharding keys using threshold signatures",
   "proposedName": "Multi-Factor Accounts",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "https://github.com/mpc-sdk/multi-factor-accounts"
   },
   "source": {
-    "shasum": "tjOLBPtFzesdnHmd3gcr0pXymj//7BaFCNxvjAfXnUI=",
+    "shasum": "HIDM3Ke0P0bhvfyVUwigS7MP+Z5pYs8NYWtaTAreqMA=",
     "location": {
       "npm": {
         "filePath": "bundle/bundle.js",


### PR DESCRIPTION
So that the production build does not use relative paths for assets.

As the cloudfront CDN redirects all routes to /index.html using a relative path will yield a 404 when not at the root of the web server.